### PR TITLE
Generalise show function

### DIFF
--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -140,8 +140,8 @@ product = foldl' (*) 1
 
 
 -- | Convert a value to readable Text
-show :: Show a => a -> Text
-show = Text.pack . Prelude.show
+show :: (Show a, IsString b) => a -> b
+show = fromString . Prelude.show
 
 -- | Parse Text to a value
 read :: Read a => Text -> a

--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -25,6 +25,7 @@ module BasicPrelude
   , product
     -- ** Text for Read and Show operations
   , show
+  , show'
   , read
   , readIO
     -- ** FilePath for file operations
@@ -140,8 +141,12 @@ product = foldl' (*) 1
 
 
 -- | Convert a value to readable Text
-show :: (Show a, IsString b) => a -> b
-show = fromString . Prelude.show
+show :: Show a => a -> Text
+show = Text.pack . Prelude.show
+
+-- | Convert a value to readable IsString
+show' :: (Show a, IsString b) => a -> b
+show' = fromString . Prelude.show
 
 -- | Parse Text to a value
 read :: Read a => Text -> a

--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -25,7 +25,7 @@ module BasicPrelude
   , product
     -- ** Text for Read and Show operations
   , show
-  , show'
+  , fromShow
   , read
   , readIO
     -- ** FilePath for file operations
@@ -145,8 +145,8 @@ show :: Show a => a -> Text
 show = Text.pack . Prelude.show
 
 -- | Convert a value to readable IsString
-show' :: (Show a, IsString b) => a -> b
-show' = fromString . Prelude.show
+fromShow :: (Show a, IsString b) => a -> b
+fromShow = fromString . Prelude.show
 
 -- | Parse Text to a value
 read :: Read a => Text -> a


### PR DESCRIPTION
```haskell
show :: Show a => a -> Text
```

This function works great in almost any situation. But some functions accept `String` or even `Bytestring`. So in such cases `String` is converted to `Text` and then to `Bytestring` or back to `String`. Which isn't nice. And for `Text` type new implementation should work almost the same as previous implementation (as far as I understand, the only overhead - is to search for the right implementation in the dictionary, right?).