### PR TITLE
Export converters between FilePath <-> Text, String.

### DIFF
--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -41,6 +41,9 @@ module BasicPrelude
   , Text.unwords
   , textToString
   , ltextToString
+  , filePathToText
+  , filePathFromText
+  , filePathToString
   , encodeUtf8
   , decodeUtf8
     -- ** Text operations (IO)
@@ -180,6 +183,17 @@ textToString = Text.unpack
 
 ltextToString :: LText -> Prelude.String
 ltextToString = LText.unpack
+
+-- | This function assumes file paths are encoded in UTF8. If it
+-- cannot decode the 'FilePath', the result is just an approximation.
+filePathToText :: FilePath -> Text
+filePathToText = either id id . FilePath.toText
+
+filePathFromText :: Text -> FilePath
+filePathFromText = FilePath.fromText
+
+filePathToString :: FilePath -> Prelude.String
+filePathToString = FilePath.encodeString
 
 -- | Note that this is /not/ the standard @Data.Text.Encoding.decodeUtf8@. That
 -- function will throw impure exceptions on any decoding errors. This function

--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -41,9 +41,9 @@ module BasicPrelude
   , Text.unwords
   , textToString
   , ltextToString
-  , filePathToText
-  , filePathFromText
-  , filePathToString
+  , fpToText
+  , fpFromText
+  , fpToString
   , encodeUtf8
   , decodeUtf8
     -- ** Text operations (IO)
@@ -186,14 +186,14 @@ ltextToString = LText.unpack
 
 -- | This function assumes file paths are encoded in UTF8. If it
 -- cannot decode the 'FilePath', the result is just an approximation.
-filePathToText :: FilePath -> Text
-filePathToText = either id id . FilePath.toText
+fpToText :: FilePath -> Text
+fpToText = either id id . FilePath.toText
 
-filePathFromText :: Text -> FilePath
-filePathFromText = FilePath.fromText
+fpFromText :: Text -> FilePath
+fpFromText = FilePath.fromText
 
-filePathToString :: FilePath -> Prelude.String
-filePathToString = FilePath.encodeString
+fpToString :: FilePath -> Prelude.String
+fpToString = FilePath.encodeString
 
 -- | Note that this is /not/ the standard @Data.Text.Encoding.decodeUtf8@. That
 -- function will throw impure exceptions on any decoding errors. This function


### PR DESCRIPTION
I think these functions are useful when you use non-FilePath-ready functions.
