### PR TITLE
Export Foldable and Traversable

### DIFF
--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -16,15 +16,16 @@ module BasicPrelude
     -- ** Folds and traversals
   , Foldable
     (
-      elem
-    , foldMap
+      foldMap
     , foldr
     , foldl
     , foldr1
     , foldl1
-    , maximum
-    , minimum
     )
+    -- In base-4.8, these are instance methods.
+  , elem
+  , maximum
+  , minimum
   , Traversable
     (
       traverse
@@ -113,15 +114,27 @@ import Data.List hiding
     -- prefer strict versions
   , sum
   , product
+    -- prefer Foldable versions
+  , elem
+  , foldl
+  , foldl1
+  , foldr
+  , foldr1
+  , maximum
+  , minimum
   )
 
 -- Import *all of the things* from Control.Monad,
 -- specifically, the list-based things that
 -- CorePrelude doesn't export
-import Control.Monad
+import Control.Monad hiding
+  ( -- Also exported by Data.Traversable.
+    mapM
+  , sequence
+  )
 
 
-import Data.Foldable (Foldable(..))
+import Data.Foldable (Foldable(..), elem, maximum, minimum)
 import Data.Traversable (Traversable(..))
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -157,11 +170,11 @@ intercalate xs xss = mconcat (Data.List.intersperse xs xss)
 
 -- | Compute the sum of a finite list of numbers.
 sum :: Num a => [a] -> a
-sum = foldl' (+) 0
+sum = Data.Foldable.foldl' (+) 0
 
 -- | Compute the product of a finite list of numbers.
 product :: Num a => [a] -> a
-product = foldl' (*) 1
+product = Data.Foldable.foldl' (*) 1
 
 
 -- | Convert a value to readable Text

--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -13,6 +13,26 @@ module BasicPrelude
   , module Data.List
   , module Control.Monad
 
+    -- ** Folds and traversals
+  , Foldable
+    (
+      elem
+    , foldMap
+    , foldr
+    , foldl
+    , foldr1
+    , foldl1
+    , maximum
+    , minimum
+    )
+  , Traversable
+    (
+      traverse
+    , sequenceA
+    , mapM
+    , sequence
+    )
+
     -- * Enhanced exports
     -- ** Simpler name for a typeclassed operation
   , map
@@ -21,8 +41,8 @@ module BasicPrelude
   , concat
   , intercalate
     -- ** Strict implementation
-  , sum
-  , product
+  , BasicPrelude.sum
+  , BasicPrelude.product
     -- ** Text for Read and Show operations
   , show
   , fromShow
@@ -101,6 +121,8 @@ import Data.List hiding
 import Control.Monad
 
 
+import Data.Foldable (Foldable(..))
+import Data.Traversable (Traversable(..))
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Text.Lazy as LText

--- a/CorePrelude.hs
+++ b/CorePrelude.hs
@@ -101,7 +101,10 @@ module CorePrelude
       -- ** Monoids
     , Monoid (..)
     , (<>)
-      -- ** Arrow
+      -- ** Folds and traversals
+    , Data.Foldable.Foldable
+    , Data.Traversable.Traversable
+      -- ** arrow
     , Control.Arrow.first
     , Control.Arrow.second
     , (Control.Arrow.***)
@@ -182,6 +185,9 @@ import qualified Control.Monad
 import qualified Control.Exception
 import qualified Control.Exception.Lifted
 import qualified Data.Typeable
+
+import qualified Data.Foldable
+import qualified Data.Traversable
 
 import Data.Word (Word8, Word32, Word64, Word)
 import Data.Int (Int32, Int64)


### PR DESCRIPTION
Export `Foldable` and `Traversable` types from `CorePrelude`, and in
`BasicPrelude`, export both the types and the functions that are
exported from the GHC 7.10 built-in `Prelude`.

Since the new Prelude includes `sum` and `product`, I've been explicit about the fact that `BasicPrelude` exports its own, strict versions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/snoyberg/basic-prelude/60)
<!-- Reviewable:end -->
