### PR TITLE
Export strict versions of generic fold functions

### DIFF
--- a/BasicPrelude.hs
+++ b/BasicPrelude.hs
@@ -18,7 +18,9 @@ module BasicPrelude
     (
       foldMap
     , foldr
+    , foldr'
     , foldl
+    , foldl'
     , foldr1
     , foldl1
     )
@@ -117,8 +119,10 @@ import Data.List hiding
     -- prefer Foldable versions
   , elem
   , foldl
+  , foldl'
   , foldl1
   , foldr
+  , foldr'
   , foldr1
   , maximum
   , minimum


### PR DESCRIPTION
This is more than the Prelude exports in base-4.8, but is probably generally useful.

As requested in https://github.com/snoyberg/basic-prelude/pull/60#issuecomment-107151557

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/snoyberg/basic-prelude/61)
<!-- Reviewable:end -->
