### PR TITLE
Needs GHC >= 7.6 due to Data.List.foldr'

### DIFF
--- a/basic-prelude.cabal
+++ b/basic-prelude.cabal
@@ -21,7 +21,7 @@ cabal-version:       >=1.8
 
 library
   exposed-modules:     BasicPrelude, CorePrelude
-  build-depends:       base                     >= 4       && < 5
+  build-depends:       base                     >= 4.6     && < 5
                      , hashable
                      , bytestring
                      , text


### PR DESCRIPTION
This only applies to basic-prelude-0.5.0 which I revised (https://hackage.haskell.org/package/basic-prelude-0.5.0/revisions/) so a new release isn't necessary.
