### PR TITLE
Add flipped versions of $ and <$> - & and <&>

### DIFF
--- a/CorePrelude.hs
+++ b/CorePrelude.hs
@@ -6,6 +6,7 @@ module CorePrelude
       -- ** Operators
       (Prelude.$)
     , (Prelude.$!)
+    , (&)
     , (Prelude.&&)
     , (Prelude.||)
     , (Control.Category..)
@@ -130,6 +131,7 @@ module CorePrelude
     , Control.Applicative.Applicative (..)
     , (Control.Applicative.<$>)
     , (Control.Applicative.<|>)
+    , (<&>)
       -- ** Monad
     , (Control.Monad.>=>)
       -- ** Transformers
@@ -246,6 +248,18 @@ infixr 6 <>
 {-# INLINE (<>) #-}
 
 #endif
+
+
+-- | Flipped version of '$'
+infixl 1 &
+(&) :: a -> (a -> b) -> b
+(&) = Data.Function.flip (Data.Function.$)
+
+-- | Flipped version of '<$>'
+infixl 5 <&>
+(<&>) :: Control.Monad.Functor f => f a -> (a -> b) -> f b
+(<&>) = Data.Function.flip (<$>)
+
 
 equating :: Eq a => (b -> a) -> b -> b -> Bool
 equating = Data.Function.on (Prelude.==)


### PR DESCRIPTION
There is a certain assymmetry between the monadic bind operator, which has both
normal and flipped version `=<<`, and `fmap`, which doesn't, despite being often
used in similar situations.

For example, the following code:

```
x >>= return . \val -> ...
```

would look a lot nicer if written

```
x <&> \val -> ...
```

Of course `<$>` could be used, but then the lambda would have to be wrapped in parens, and that is just ugly.

So I think adding these to CorePrelude (and thus ClassyPrelude) wouldn't hurt.
The operators seem to be used in a few places in Hackage. `<&>` is defined in
[lens](http://haddock.stackage.org/lts-2.19/lens-4.7.0.1/Control-Lens-Lens.html#v:-60--38--62-), `&` in [base-prelude](https://www.stackage.org/haddock/lts-2.19/base-prelude-0.1.19/BasePrelude.html#v:-38-), [lens-family-core](https://www.stackage.org/haddock/lts-2.19/lens-family-core-1.2.0/Lens-Family.html#v:-38-), [hsdev](https://www.stackage.org/haddock/lts-2.19/hsdev-0.1.3.4/Control-Apply-Util.html#v:-38-), [lens](https://www.stackage.org/haddock/lts-2.19/diagrams-lib-1.2.0.9/Diagrams-Prelude-ThreeD.html#v:-38-).
