### PR TITLE
Remove read args, switch to safe-exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18
     compiler: ": #GHC 7.8.4"
     addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 0.7.0
 
 * Remove ReadArgs dependency
+* Switched from `lifted-base` to `safe-exceptions`
 
 ## 0.6.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+* Remove ReadArgs dependency
+
 ## 0.6.1
 
 * Generalize `sum` and `product` to `Foldable` [#69](https://github.com/snoyberg/basic-prelude/issues/69)

--- a/CorePrelude.hs
+++ b/CorePrelude.hs
@@ -170,8 +170,6 @@ module CorePrelude
       -- ** Hashing
     , hash
     , hashWithSalt
-      -- ** Command line args
-    , readArgs
     ) where
 
 import qualified Prelude
@@ -222,7 +220,6 @@ import Data.IntSet (IntSet)
 import Data.Sequence (Seq)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
-import qualified ReadArgs
 import qualified System.FilePath as F
 
 import qualified System.Environment
@@ -274,9 +271,6 @@ putStrLn = liftIO . Data.Text.IO.putStrLn
 
 print :: (MonadIO m, Prelude.Show a) => a -> m ()
 print = liftIO . Prelude.print
-
-readArgs :: (MonadIO m, ReadArgs.ArgumentTuple a) => m a
-readArgs = liftIO ReadArgs.readArgs
 
 -- | @error@ applied to @Text@
 --

--- a/CorePrelude.hs
+++ b/CorePrelude.hs
@@ -144,22 +144,22 @@ module CorePrelude
     , Data.Typeable.Typeable (..)
     , Control.Exception.SomeException
     , Control.Exception.IOException
-    , Control.Exception.Lifted.throwIO
-    , Control.Exception.Lifted.try
-    , Control.Exception.Lifted.tryJust
-    , Control.Exception.Lifted.catch
-    , Control.Exception.Lifted.catchJust
-    , Control.Exception.Lifted.handle
-    , Control.Exception.Lifted.handleJust
-    , Control.Exception.Lifted.bracket
-    , Control.Exception.Lifted.bracket_
-    , Control.Exception.Lifted.bracketOnError
-    , Control.Exception.Lifted.onException
-    , Control.Exception.Lifted.finally
-    , Control.Exception.Lifted.mask
-    , Control.Exception.Lifted.mask_
-    , Control.Exception.Lifted.uninterruptibleMask
-    , Control.Exception.Lifted.uninterruptibleMask_
+    , Control.Exception.Safe.throwIO
+    , Control.Exception.Safe.try
+    , Control.Exception.Safe.tryJust
+    , Control.Exception.Safe.catch
+    , Control.Exception.Safe.catchJust
+    , Control.Exception.Safe.handle
+    , Control.Exception.Safe.handleJust
+    , Control.Exception.Safe.bracket
+    , Control.Exception.Safe.bracket_
+    , Control.Exception.Safe.bracketOnError
+    , Control.Exception.Safe.onException
+    , Control.Exception.Safe.finally
+    , Control.Exception.Safe.mask
+    , Control.Exception.Safe.mask_
+    , Control.Exception.Safe.uninterruptibleMask
+    , Control.Exception.Safe.uninterruptibleMask_
     , module System.IO.Error
       -- ** Files
     , Prelude.FilePath
@@ -184,7 +184,7 @@ import Control.Applicative
 import qualified Control.Category
 import qualified Control.Monad
 import qualified Control.Exception
-import qualified Control.Exception.Lifted
+import qualified Control.Exception.Safe
 import qualified Data.Typeable
 
 import qualified Data.Foldable

--- a/basic-prelude.cabal
+++ b/basic-prelude.cabal
@@ -1,5 +1,5 @@
 name:                basic-prelude
-version:             0.6.1
+version:             0.7.0
 synopsis:            An enhanced core prelude; a common foundation for alternate preludes.
 description:
     The premise of @basic-prelude@ is that there are a lot of very commonly desired features missing from the standard @Prelude@, such as commonly used operators (@\<$\>@ and @>=>@, for instance) and imports for common datatypes (e.g., @ByteString@ and @Vector@). At the same time, there are lots of other components which are more debatable, such as providing polymorphic versions of common functions.
@@ -29,7 +29,6 @@ library
                      , containers
                      , unordered-containers
                      , vector
-                     , ReadArgs                 >= 1.2     && < 1.3
                      , lifted-base
                      , safe
                      , filepath

--- a/basic-prelude.cabal
+++ b/basic-prelude.cabal
@@ -29,7 +29,7 @@ library
                      , containers
                      , unordered-containers
                      , vector
-                     , lifted-base
+                     , safe-exceptions
                      , safe
                      , filepath
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,8 @@ resolver: lts-5.5
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- safe-exceptions-0.1.4.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Pinging @gregwebs and @DanBurton for feedback. Greg: I think you weren't in favor of ReadArgs in the first place. For safe-exceptions, I think it's overall a better approach, and provides async safety.
